### PR TITLE
Nam-116 -- ENG & UI: Update recognized

### DIFF
--- a/app/Contracts/UpdateRecognizedContract.php
+++ b/app/Contracts/UpdateRecognizedContract.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+interface UpdateRecognizedContract
+{
+    public function markAsRecognized();
+
+    public function markAsUnrecognized();
+}

--- a/app/Http/Controllers/RecognizedController.php
+++ b/app/Http/Controllers/RecognizedController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Contracts\UpdateRecognizedContract;
+
+class RecognizedController extends Controller
+{
+    protected $recognizedContract = null;
+
+    public function __construct(UpdateRecognizedContract $recognizedContract)
+    {
+        $this->recognizedContract = $recognizedContract;
+    }
+
+    public function markAsRecognized()
+    {
+        $this->recognizedContract->markAsRecognized();
+    }
+
+    public function markAsUnrecognized()
+    {
+        $this->recognizedContract->markAsUnrecognized();
+    }
+}

--- a/app/Providers/UpdateRecognizedServiceProvider.php
+++ b/app/Providers/UpdateRecognizedServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class UpdateRecognizedServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap the application services.
+     */
+    public function boot()
+    {
+    }
+
+    /**
+     * Register the application services.
+     */
+    public function register()
+    {
+        $this->app->bind(
+            'App\Contracts\UpdateRecognizedContract',
+            'App\Services\UpdateRecognizedService'
+        );
+    }
+}

--- a/app/Services/UpdateRecognizedService.php
+++ b/app/Services/UpdateRecognizedService.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\UpdateRecognizedContract;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class UpdateRecognizedService implements UpdateRecognizedContract
+{
+    public function markAsRecognized()
+    {
+        $student_id = request()->student_id;
+        $professor_id = Auth::user()->user_id;
+        DB::table('recognitions')->insert([
+            'professor_id' => $professor_id,
+            'student_id' => $student_id,
+        ]);
+
+        Cache::forget('students');
+    }
+
+    public function markAsUnrecognized()
+    {
+        $student_id = request()->student_id;
+        $professor_id = Auth::user()->user_id;
+        DB::table('recognitions')
+            ->where('professor_id', $professor_id)
+            ->where('student_id', $student_id)
+            ->delete();
+
+        Cache::forget('students');
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -171,6 +171,7 @@ return [
         App\Providers\WebResourceServiceProvider::class,
         App\Providers\RosterServiceProvider::class,
         App\Providers\ImageCRUDServiceProvider::class,
+        App\Providers\UpdateRecognizedServiceProvider::class,
 
         /*
          * Application Service Providers...

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -15876,6 +15876,12 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
+//
+//
+//
+//
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
@@ -15884,7 +15890,8 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
     },*/
     data: function data() {
         return {
-            errors: []
+            errors: [],
+            messages: true
         };
     },
 
@@ -15924,6 +15931,27 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             }).catch(function (e) {
                 _this.errors.push(e);
             });
+        },
+
+        updateRecognized: function updateRecognized(recognized, id) {
+            var _this2 = this;
+
+            var data = new FormData();
+            data.append('student_id', id);
+
+            if (recognized) {
+                this.axios.post('http://nameface.test/markAsUnrecognized', data).then(function (response) {
+                    console.log(response);
+                }).catch(function (e) {
+                    _this2.errors.push(e);
+                });
+            } else {
+                this.axios.post('http://nameface.test/markAsRecognized', data).then(function (response) {
+                    console.log(response);
+                }).catch(function (e) {
+                    _this2.errors.push(e);
+                });
+            }
         }
     },
 
@@ -15974,7 +16002,41 @@ var render = function() {
                   accept: "image/*"
                 }
               })
-            ])
+            ]),
+            _vm._v(" "),
+            student.recognized
+              ? _c("div", [
+                  _c(
+                    "button",
+                    {
+                      on: {
+                        click: function($event) {
+                          _vm.updateRecognized(
+                            student.recognized,
+                            student.student_id
+                          )
+                        }
+                      }
+                    },
+                    [_vm._v("Mark as unrecognized")]
+                  )
+                ])
+              : _c("div", [
+                  _c(
+                    "button",
+                    {
+                      on: {
+                        click: function($event) {
+                          _vm.updateRecognized(
+                            student.recognized,
+                            student.student_id
+                          )
+                        }
+                      }
+                    },
+                    [_vm._v("Mark as recognized")]
+                  )
+                ])
           ])
         ])
       ])

--- a/resources/src/js/components/cardImages.vue
+++ b/resources/src/js/components/cardImages.vue
@@ -11,6 +11,12 @@
 						<div class="crop">
 								<img :id="student.display_name+'-img'" :src="student.image" class="img--circle crop img" name="photo" accept="image/*">
 						</div>
+                        <div v-if="student.recognized">
+                            <button v-on:click="updateRecognized(student.recognized, student.student_id);">Mark as unrecognized</button>
+                        </div>
+                        <div v-else>
+                            <button v-on:click="updateRecognized(student.recognized, student.student_id);">Mark as recognized</button>
+                        </div>
 					</label>
 			</div>
 		</div>
@@ -26,6 +32,7 @@ export default {
     data: function () {
         return {
             errors: [],
+            messages: true
         }
     },
 
@@ -65,7 +72,32 @@ export default {
                 .catch(e => {
                     this.errors.push(e)
                 });
-		}
+		},
+
+
+		updateRecognized: function(recognized, id) {
+
+            let data = new FormData();
+            data.append('student_id', id);
+
+            if(recognized) {
+                this.axios.post('http://nameface.test/markAsUnrecognized', data)
+                    .then(response => {
+                        console.log(response);
+                        })
+                    .catch(e => {
+                        this.errors.push(e)
+                        });
+            } else {
+                this.axios.post('http://nameface.test/markAsRecognized', data)
+                    .then(response => {
+                        console.log(response);
+                         })
+                    .catch(e => {
+                        this.errors.push(e)
+                        });
+            }
+        }
     },
 
     props: ['students']

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,12 @@ Route::get('/media', 'WebResourceController@media');
 Route::get('/students/{term}/{course}', 'RosterController@getStudents');
 Route::get('/students/shuffle/{term}/{course}', 'RosterController@shuffleStudents');
 
+
+/**
+ * Update recognized routes
+ */
+Route::post('/markAsRecognized', 'RecognizedController@markAsRecognized')->middleware('auth');
+Route::post('/markAsUnrecognized', 'RecognizedController@markAsUnrecognized')->middleware('auth');
 /**
  * META+LAB Feedback Routes
  */


### PR DESCRIPTION
# Description
Made a way to update the recognized field on the front end which links to the backend and updates the values.

NOTE:
You currently need to refresh after pushing the button for the changes to be applied to the front end. Creating a solution for this right now would be pointless because once we re-factor the students outside of the grid, the issue can be solved trivially.

# Installation
n/a

# Testing
1. Log in
2. Mark a student as recognized, and then refresh the page
3. Mark the same student as unrecognized, and then refresh the page