### PR TITLE
NAM-161 -- ENG: Cannot Log in as another professor unless cache is cleared on the backend

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -29,6 +29,9 @@ class LoginController extends Controller
      */
     public function index()
     {
+        if (auth()->user()) {
+            return redirect('home');
+        }
         return view('login');
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ Route::get('/data', 'SPAController@getData')->middleware('auth');
 /** Route for logout. */
 Route::get('/logout', function () {
     auth()->logout();
+    cache()->clear();
     return redirect('/');
 });
 


### PR DESCRIPTION
# Description
> This is a bug that we need to look into to get a good fix that doesn't clear the cache when the same professor logs in, but does when its different.
This also involves making another dummy class for steve so we can start testing two professor interactions
***
# Testing
* Verify that log-in page redirects home if logged in
* Verify that after logging out and logging in as a new user, data is correct