### PR TITLE
NAM-186 -- ENG: Change note saving to be on device, or encrypted in the server

### DIFF
--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Crypt;
 class Note extends Model
 {
     protected $fillable = ['student_id', 'user_id', 'notepad'];
+    protected $attributes = ['notepad' => 'empty'];
 
     protected function setNotepadAttribute($value)
     {
@@ -18,6 +19,9 @@ class Note extends Model
 
     protected function getNotepadAttribute($value)
     {
+        if ($value == 'empty') {
+            return 'empty';
+        }
         return Crypt::decrypt($value);
     }
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -5,8 +5,19 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Crypt;
 
 class Note extends Model
 {
-    protected $fillable = ['notepad', 'student_id', 'user_id'];
+    protected $fillable = ['student_id', 'user_id', 'notepad'];
+
+    protected function setNotepadAttribute($value)
+    {
+        return Crypt::encrypt($value);
+    }
+
+    protected function getNotepadAttribute($value)
+    {
+        return Crypt::decrypt($value);
+    }
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -5,23 +5,8 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Crypt;
 
 class Note extends Model
 {
     protected $fillable = ['student_id', 'user_id', 'notepad'];
-    protected $attributes = ['notepad' => 'empty'];
-
-    protected function setNotepadAttribute($value)
-    {
-        return Crypt::encrypt($value);
-    }
-
-    protected function getNotepadAttribute($value)
-    {
-        if ($value == 'empty') {
-            return 'empty';
-        }
-        return Crypt::decrypt($value);
-    }
 }

--- a/app/Services/StudentProfileService.php
+++ b/app/Services/StudentProfileService.php
@@ -71,7 +71,7 @@ class StudentProfileService implements StudentProfileContract
             ->where('student_id', $request->student_id)
             ->first();
 
-        if ($note !== null) {
+        if ($note) {
             $note->notepad = $request->notepad;
             $note->save();
 

--- a/app/Services/StudentProfileService.php
+++ b/app/Services/StudentProfileService.php
@@ -68,7 +68,7 @@ class StudentProfileService implements StudentProfileContract
     public function updateStudentNotes(Request $request)
     {
         $note = Note::updateOrCreate(
-            ['user_id' => auth()->user()->user_id, 'student_id' => $request->student_id],
+            ['user_id' => $request->faculty_id, 'student_id' => $request->student_id],
             ['notepad' => $request->notepad]
         );
     }

--- a/app/Services/StudentProfileService.php
+++ b/app/Services/StudentProfileService.php
@@ -10,6 +10,7 @@ use App\Contracts\StudentProfileContract;
 use App\Contracts\WebResourceRetrieverContract;
 use App\Models\Note;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Crypt;
 use Intervention\Image\ImageManager;
 
 class StudentProfileService implements StudentProfileContract
@@ -54,7 +55,7 @@ class StudentProfileService implements StudentProfileContract
             'email' => $email,
             'student_id' => $profile['individuals_id'],
             'members_id' => $profile['individuals_id'],
-            'notes' => $note == null ? 'Notes go here.' : $note->notepad,
+            'notes' => $note == null ? 'Notes go here.' : Crypt::decrypt($note->notepad),
             'image_priority' => $imagePriority,
         ];
 
@@ -72,7 +73,7 @@ class StudentProfileService implements StudentProfileContract
             ->first();
 
         if ($note) {
-            $note->notepad = $request->notepad;
+            $note->notepad = Crypt::encrypt($request->notepad);
             $note->save();
 
             return 'Updated';
@@ -80,7 +81,7 @@ class StudentProfileService implements StudentProfileContract
         $note = new Note();
         $note->user_id = auth()->user()->user_id;
         $note->student_id = $request->student_id;
-        $note->notepad = $request->notepad;
+        $note->notepad = Crypt::encrypt($request->notepad);
         $note->save();
 
         return 'Created';

--- a/app/Services/StudentProfileService.php
+++ b/app/Services/StudentProfileService.php
@@ -67,9 +67,22 @@ class StudentProfileService implements StudentProfileContract
 
     public function updateStudentNotes(Request $request)
     {
-        $note = Note::updateOrCreate(
-            ['user_id' => $request->faculty_id, 'student_id' => $request->student_id],
-            ['notepad' => $request->notepad]
-        );
+        $note = Note::where('user_id', auth()->user()->user_id)
+            ->where('student_id', $request->student_id)
+            ->first();
+
+        if ($note !== null) {
+            $note->notepad = $request->notepad;
+            $note->save();
+
+            return 'Updated';
+        }
+        $note = new Note();
+        $note->user_id = auth()->user()->user_id;
+        $note->student_id = $request->student_id;
+        $note->notepad = $request->notepad;
+        $note->save();
+
+        return 'Created';
     }
 }

--- a/app/Services/StudentProfileService.php
+++ b/app/Services/StudentProfileService.php
@@ -72,18 +72,11 @@ class StudentProfileService implements StudentProfileContract
             ->where('student_id', $request->student_id)
             ->first();
 
-        if ($note) {
-            $note->notepad = Crypt::encrypt($request->notepad);
-            $note->save();
+        $note = Note::updateOrCreate(
+            ['user_id' => auth()->user()->user_id, 'student_id' => $request->student_id],
+            ['notepad' => Crypt::encrypt($request->notepad)]
+        );
 
-            return 'Updated';
-        }
-        $note = new Note();
-        $note->user_id = auth()->user()->user_id;
-        $note->student_id = $request->student_id;
-        $note->notepad = Crypt::encrypt($request->notepad);
-        $note->save();
-
-        return 'Created';
+        return 'Updated';
     }
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19220,11 +19220,11 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
     },
 
     created: function created() {
-        this.$store.dispatch('getStudentProfile', { uri: this.$route.params.emailURI });
+        this.$store.dispatch('getStudentProfile', { uri: this.$route.params.emailURI, faculty_id: this.facultyMember.id });
     },
 
 
-    computed: _extends({}, Object(__WEBPACK_IMPORTED_MODULE_0_vuex__["b" /* mapGetters */])(['studentProfile']), Object(__WEBPACK_IMPORTED_MODULE_0_vuex__["c" /* mapState */])({
+    computed: _extends({}, Object(__WEBPACK_IMPORTED_MODULE_0_vuex__["b" /* mapGetters */])(['studentProfile', 'facultyMember']), Object(__WEBPACK_IMPORTED_MODULE_0_vuex__["c" /* mapState */])({
         sp_notes: function sp_notes(state) {
             return state.profile.studentProfile.notes;
         }
@@ -19235,7 +19235,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
             this.$store.dispatch('updateNotes', e.target.value);
         },
         commitNotes: function commitNotes() {
-            this.$store.dispatch('commitNotes');
+            this.$store.dispatch('commitNotes', this.facultyMember.id);
         },
         croppaToggle: function croppaToggle() {
             this.showcroppa = !this.showcroppa;
@@ -20191,8 +20191,8 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
     updateNotes: function updateNotes(context, notes) {
         context.commit('UPDATE_NOTES', notes);
     },
-    commitNotes: function commitNotes(context, payload) {
-        context.commit('COMMIT_NOTES', payload);
+    commitNotes: function commitNotes(context, facultyID) {
+        context.commit('COMMIT_NOTES', facultyID);
     },
     updateImagePriority: function updateImagePriority(context, payload) {
         context.commit('UPDATE_IMAGE_PRIORITY', payload);
@@ -20209,8 +20209,15 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
 "use strict";
 /* harmony default export */ __webpack_exports__["a"] = ({
     GET_STUDENT_PROFILE: function GET_STUDENT_PROFILE(state, payload) {
+        var email = payload.uri + '@my.csun.edu';
+        var data = new FormData();
+
+        data.append('faculty_id', payload.faculty_id);
+        data.append('email', email);
+
         state.studentProfile.emailURI = payload.uri;
-        axios.get('student/' + state.studentProfile.emailURI + '@my.csun.edu').then(function (response) {
+
+        axios.get('student/' + email).then(function (response) {
             state.studentProfile.bio = response['data']['people'].biography;
 
             if (state.studentProfile.bio === null) state.studentProfile.bio = "Pending biography from student.";
@@ -20218,7 +20225,7 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
             console.log(e);
         });
 
-        axios.get('student_profile/' + state.studentProfile.emailURI + '@my.csun.edu').then(function (response) {
+        axios.get('student_profile/', data).then(function (response) {
             state.studentProfile.displayName = response['data'].display_name;
             state.studentProfile.images = response['data'].images;
             state.studentProfile.imagePriority = response['data'].image_priority;
@@ -20233,8 +20240,9 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
         state.studentProfile.notes = notes;
     },
 
-    COMMIT_NOTES: function COMMIT_NOTES(state) {
+    COMMIT_NOTES: function COMMIT_NOTES(state, facultyID) {
         var data = new FormData();
+        data.append('faculty_id', facultyID);
         data.append('student_id', state.studentProfile.id);
         data.append('notepad', state.studentProfile.notes);
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -20246,11 +20246,9 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
         data.append('student_id', state.studentProfile.id);
         data.append('notepad', state.studentProfile.notes);
 
-        console.log("before");
         axios.post('update_note', data).catch(function (e) {
             console.log(e);
         });
-        console.log("after");
     },
 
     UPDATE_IMAGE_PRIORITY: function UPDATE_IMAGE_PRIORITY(state, payload) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -20225,7 +20225,7 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
             console.log(e);
         });
 
-        axios.get('student_profile/', data).then(function (response) {
+        axios.get('student_profile/' + email).then(function (response) {
             state.studentProfile.displayName = response['data'].display_name;
             state.studentProfile.images = response['data'].images;
             state.studentProfile.imagePriority = response['data'].image_priority;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19235,7 +19235,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
             this.$store.dispatch('updateNotes', e.target.value);
         },
         commitNotes: function commitNotes() {
-            this.$store.dispatch('commitNotes', this.facultyMember.id);
+            this.$store.dispatch('commitNotes');
         },
         croppaToggle: function croppaToggle() {
             this.showcroppa = !this.showcroppa;
@@ -20191,8 +20191,8 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
     updateNotes: function updateNotes(context, notes) {
         context.commit('UPDATE_NOTES', notes);
     },
-    commitNotes: function commitNotes(context, facultyID) {
-        context.commit('COMMIT_NOTES', facultyID);
+    commitNotes: function commitNotes(context) {
+        context.commit('COMMIT_NOTES');
     },
     updateImagePriority: function updateImagePriority(context, payload) {
         context.commit('UPDATE_IMAGE_PRIORITY', payload);
@@ -20240,9 +20240,8 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
         state.studentProfile.notes = notes;
     },
 
-    COMMIT_NOTES: function COMMIT_NOTES(state, facultyID) {
+    COMMIT_NOTES: function COMMIT_NOTES(state) {
         var data = new FormData();
-        data.append('faculty_id', facultyID);
         data.append('student_id', state.studentProfile.id);
         data.append('notepad', state.studentProfile.notes);
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19204,8 +19204,6 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 //
 //
 //
-//
-//
 
 
 
@@ -19716,22 +19714,25 @@ var render = function() {
             _c("div", { staticClass: "container" }, [
               _c("div", { staticClass: "row" }, [
                 _c("div", { staticClass: "col-sm-12" }, [
-                  _c("form", [
-                    _c("textarea", {
-                      attrs: { type: "text", id: "ex0", name: "ex0" },
-                      domProps: { value: _vm.sp_notes },
-                      on: { input: _vm.updateNotes }
-                    }),
-                    _vm._v(" "),
-                    _c(
-                      "button",
-                      {
-                        staticClass: "btn btn-default",
-                        on: { click: _vm.commitNotes }
-                      },
-                      [_vm._v("Add a Note")]
-                    )
-                  ]),
+                  _c("textarea", {
+                    attrs: { type: "text", id: "ex0", name: "ex0" },
+                    domProps: { value: _vm.sp_notes },
+                    on: { input: _vm.updateNotes }
+                  }),
+                  _vm._v(" "),
+                  _c(
+                    "button",
+                    {
+                      staticClass: "btn btn-default",
+                      on: {
+                        click: function($event) {
+                          $event.preventDefault()
+                          _vm.commitNotes($event)
+                        }
+                      }
+                    },
+                    [_vm._v("Add a Note")]
+                  ),
                   _vm._v(" "),
                   _c("br"),
                   _vm._v(" "),
@@ -20245,9 +20246,11 @@ var store = new __WEBPACK_IMPORTED_MODULE_5_vuex__["a" /* default */].Store({
         data.append('student_id', state.studentProfile.id);
         data.append('notepad', state.studentProfile.notes);
 
+        console.log("before");
         axios.post('update_note', data).catch(function (e) {
             console.log(e);
         });
+        console.log("after");
     },
 
     UPDATE_IMAGE_PRIORITY: function UPDATE_IMAGE_PRIORITY(state, payload) {

--- a/resources/src/js/store/modules/profile/actions.js
+++ b/resources/src/js/store/modules/profile/actions.js
@@ -7,8 +7,8 @@ export default {
         context.commit('UPDATE_NOTES', notes);
     },
 
-    commitNotes (context, payload) {
-        context.commit('COMMIT_NOTES', payload);
+    commitNotes (context, facultyID) {
+        context.commit('COMMIT_NOTES', facultyID);
     },
 
     updateImagePriority (context, payload) {

--- a/resources/src/js/store/modules/profile/actions.js
+++ b/resources/src/js/store/modules/profile/actions.js
@@ -7,8 +7,8 @@ export default {
         context.commit('UPDATE_NOTES', notes);
     },
 
-    commitNotes (context, facultyID) {
-        context.commit('COMMIT_NOTES', facultyID);
+    commitNotes (context) {
+        context.commit('COMMIT_NOTES');
     },
 
     updateImagePriority (context, payload) {

--- a/resources/src/js/store/modules/profile/mutations.js
+++ b/resources/src/js/store/modules/profile/mutations.js
@@ -1,7 +1,14 @@
 export default {
     GET_STUDENT_PROFILE: function (state, payload) {
+        let email = payload.uri+'@my.csun.edu';
+        let data = new FormData;
+
+        data.append('faculty_id', payload.faculty_id);
+        data.append('email', email);
+
         state.studentProfile.emailURI = payload.uri;
-        axios.get('student/'+state.studentProfile.emailURI+'@my.csun.edu')
+
+        axios.get('student/'+email)
             .then(response => {
                 state.studentProfile.bio = response['data']['people'].biography;
 
@@ -12,7 +19,7 @@ export default {
                 console.log(e);
             });
 
-        axios.get('student_profile/'+state.studentProfile.emailURI+'@my.csun.edu')
+        axios.get('student_profile/', data)
             .then(response => {
                 state.studentProfile.displayName = response['data'].display_name;
                 state.studentProfile.images = response['data'].images;
@@ -29,8 +36,9 @@ export default {
         state.studentProfile.notes = notes;
     },
 
-    COMMIT_NOTES: function (state) {
+    COMMIT_NOTES: function (state, facultyID) {
         let data = new FormData;
+        data.append('faculty_id', facultyID);
         data.append('student_id', state.studentProfile.id);
         data.append('notepad', state.studentProfile.notes);
 

--- a/resources/src/js/store/modules/profile/mutations.js
+++ b/resources/src/js/store/modules/profile/mutations.js
@@ -41,12 +41,10 @@ export default {
         data.append('student_id', state.studentProfile.id);
         data.append('notepad', state.studentProfile.notes);
 
-        console.log("before");
         axios.post('update_note', data)
             .catch(e => {
                 console.log(e)
             });
-        console.log("after");
     },
 
     UPDATE_IMAGE_PRIORITY: function (state, payload) {

--- a/resources/src/js/store/modules/profile/mutations.js
+++ b/resources/src/js/store/modules/profile/mutations.js
@@ -41,10 +41,12 @@ export default {
         data.append('student_id', state.studentProfile.id);
         data.append('notepad', state.studentProfile.notes);
 
+        console.log("before");
         axios.post('update_note', data)
             .catch(e => {
                 console.log(e)
             });
+        console.log("after");
     },
 
     UPDATE_IMAGE_PRIORITY: function (state, payload) {

--- a/resources/src/js/store/modules/profile/mutations.js
+++ b/resources/src/js/store/modules/profile/mutations.js
@@ -36,9 +36,8 @@ export default {
         state.studentProfile.notes = notes;
     },
 
-    COMMIT_NOTES: function (state, facultyID) {
+    COMMIT_NOTES: function (state) {
         let data = new FormData;
-        data.append('faculty_id', facultyID);
         data.append('student_id', state.studentProfile.id);
         data.append('notepad', state.studentProfile.notes);
 

--- a/resources/src/js/store/modules/profile/mutations.js
+++ b/resources/src/js/store/modules/profile/mutations.js
@@ -19,7 +19,7 @@ export default {
                 console.log(e);
             });
 
-        axios.get('student_profile/', data)
+        axios.get('student_profile/'+email)
             .then(response => {
                 state.studentProfile.displayName = response['data'].display_name;
                 state.studentProfile.images = response['data'].images;

--- a/resources/src/js/views/profile.vue
+++ b/resources/src/js/views/profile.vue
@@ -134,7 +134,7 @@
             },
 
             commitNotes () {
-                this.$store.dispatch('commitNotes', this.facultyMember.id);
+                this.$store.dispatch('commitNotes');
             },
 
             croppaToggle(){

--- a/resources/src/js/views/profile.vue
+++ b/resources/src/js/views/profile.vue
@@ -114,12 +114,13 @@
         },
 
         created () {
-            this.$store.dispatch('getStudentProfile', { uri: this.$route.params.emailURI });
+            this.$store.dispatch('getStudentProfile', { uri: this.$route.params.emailURI, faculty_id: this.facultyMember.id });
         },
 
         computed: {
             ...mapGetters([
                 'studentProfile',
+                'facultyMember'
             ]),
 
             ...mapState({
@@ -133,7 +134,7 @@
             },
 
             commitNotes () {
-                this.$store.dispatch('commitNotes');
+                this.$store.dispatch('commitNotes', this.facultyMember.id);
             },
 
             croppaToggle(){

--- a/resources/src/js/views/profile.vue
+++ b/resources/src/js/views/profile.vue
@@ -83,10 +83,8 @@
                 <div class="container">
                     <div class="row">
                         <div class="col-sm-12">
-                            <form>
-                                <textarea type="text" id="ex0" name="ex0"  :value="sp_notes" @input="updateNotes"></textarea>
-                                <button class="btn btn-default" @click="commitNotes">Add a Note</button>
-                            </form>
+                            <textarea type="text" id="ex0" name="ex0" :value="sp_notes" @input="updateNotes"></textarea>
+                            <button class="btn btn-default" @click.prevent="commitNotes">Add a Note</button>
                             <br>
                             <h4>{{this.studentProfile.emailURI}}@my.csun.edu</h4>
                             <br>


### PR DESCRIPTION
# Description
> Due to security concerns with notes, they should be encrypted in some way that only the note-taker can read them / have access to them.
If this is too complex to add, notes should not be saved on an individual device instead
***
# Testing
**NOTE:** Unencrypted DB entries will break the logic, so remove any pre-existing rows before testing, if applicable.
* Notes can be updated and viewed in plain-text on front-end
* Notes are encrypted in DB
