### PR TITLE
NAM-191 -- UI: Scroll state is being transferred over when the page updates

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -15953,7 +15953,11 @@ var router = new __WEBPACK_IMPORTED_MODULE_1_vue_router__["a" /* default */]({
         path: '/profile/:emailURI',
         component: __WEBPACK_IMPORTED_MODULE_4__views_profile___default.a,
         props: true
-    }]
+    }],
+
+    scrollBehavior: function scrollBehavior(to, from, savedPosition) {
+        return { x: 0, y: 0 };
+    }
 });
 
 /* harmony default export */ __webpack_exports__["a"] = (router);

--- a/resources/src/js/router/index.js
+++ b/resources/src/js/router/index.js
@@ -7,21 +7,25 @@ import Profile from '../views/profile';
 Vue.use(VueRouter);
 
 const router = new VueRouter({
-   routes: [
-       {
-           path: '/',
-           component: Home
-       },
-       {
-           path: '/class/:id',
-           component: Class
-       },
-       {
-           path: '/profile/:emailURI',
-           component: Profile,
-           props: true
-       }
-   ],
+    routes: [
+        {
+            path: '/',
+            component: Home
+        },
+        {
+            path: '/class/:id',
+            component: Class
+        },
+        {
+            path: '/profile/:emailURI',
+            component: Profile,
+            props: true
+        }
+    ],
+
+    scrollBehavior (to, from, savedPosition) {
+        return { x: 0, y: 0 }
+    }
 });
 
 export default router;


### PR DESCRIPTION
# Description
> When I move to a new page (ex. from course list to student list) I should appear at the top of the student list rather than at the same scroll location on the page.