### PR TITLE
8-6-2018-wrongClassesAreGettingPulled

### DIFF
--- a/app/Http/Controllers/SPAController.php
+++ b/app/Http/Controllers/SPAController.php
@@ -37,26 +37,26 @@ class SPAController extends Controller
     {
         $id = auth()->user() ? auth()->user()->getAuthIdentifier() : 'default';
 
-        if (Cache::has('courses:' . $id) && Cache::get('term:' . $id) == $term) {
-            $courses = Cache::get('courses:' . $id);
+        if ($term == null) {
+            $term = $this->userSettings->getCurrentTerm();
+        }
+
+        if (Cache::has('courses:' . $id . 'term:' . $term)) {
+            $courses = Cache::get('courses:' . $id . 'term:' . $term);
         } else {
-            if ($term == null) {
-                $term = $this->userSettings->getCurrentTerm();
-            }
             $courses = $this->webResourceRetrieverContract->getCourses($term);
-            Cache::put('courses:' . $id, $courses, $this->minutes);
-            Cache::put('term:' . $id, $term, $this->minutes);
+            Cache::put('courses:' . $id . 'term:' . $term, $courses, $this->minutes);
         }
 
         $students = [];
         $len = \count($courses);
 
         for ($i = 0; $i < $len; ++$i) {
-            if (Cache::has('students:' . $i . ':' . $id) && Cache::get('term:' . $id) == $term) {
-                $students[$i] = Cache::get('students:' . $i . ':' . $id);
+            if (Cache::has('students:' . $i . ':' . $id . 'term:' . $term)) {
+                $students[$i] = Cache::get('students:' . $i . ':' . $id . 'term:' . $term);
             } else {
                 $students[$i] = $this->rosterRetrievalContract->getStudentsFromRoster($term, $i);
-                Cache::put('students:' . $i . ':' . $id, $students[$i], $this->minutes);
+                Cache::put('students:' . $i . ':' . $id . 'term:' . $term, $students[$i], $this->minutes);
             }
 
             $courses[$i]->roster = $students[$i];

--- a/app/Services/RosterRetrievalService.php
+++ b/app/Services/RosterRetrievalService.php
@@ -85,7 +85,6 @@ class RosterRetrievalService implements RosterRetrievalContract
             $imageManager = new ImageManager(['driver' => 'imagick']);
         }
 
-        dd($student);
         $email = \str_replace('nr_', '', $student->email);
         $email = \substr($email, 0, \strpos($email, '@'));
         $imageLocation = url('images/likeness.jpg');

--- a/app/Services/RosterRetrievalService.php
+++ b/app/Services/RosterRetrievalService.php
@@ -85,6 +85,7 @@ class RosterRetrievalService implements RosterRetrievalContract
             $imageManager = new ImageManager(['driver' => 'imagick']);
         }
 
+        dd($student);
         $email = \str_replace('nr_', '', $student->email);
         $email = \substr($email, 0, \strpos($email, '@'));
         $imageLocation = url('images/likeness.jpg');


### PR DESCRIPTION
# Description
Fixes the way cacheing works in order to try and prevent the wrong classes to persist in the roster
  
# Testing
Ensure that when you try to access a professors other classes, the same students don't get pulled into the classes

(on dev)
1. Log in as Steve and go to term 2173
2. Go to term 2157 (this should fail due to the way emails are setup for the students in this class but that's a good thing for now since it is pulling the correct set of students whether they work or not)

# Installation
php artisan cache:clear
Clear application data from browser
