### PR TITLE
NAM-279 -- UI: Default view when logging in should be First Name A - Z

### DIFF
--- a/app/Services/RosterRetrievalService.php
+++ b/app/Services/RosterRetrievalService.php
@@ -125,7 +125,12 @@ class RosterRetrievalService implements RosterRetrievalContract
         ];
     }
 
-    private function sortStudents()
+    private function sortStudents($students)
     {
+        \usort($students, function ($a, $b) {
+            return $a['first_name'] <=> $b['first_name'];
+        });
+
+        return $students;
     }
 }

--- a/app/Services/RosterRetrievalService.php
+++ b/app/Services/RosterRetrievalService.php
@@ -76,7 +76,9 @@ class RosterRetrievalService implements RosterRetrievalContract
             return \strcmp($a['last_name'], $b['last_name']);
         });
 
-        return $sanitizedStudents;
+        $sortedStudents = $this->sortStudents($sanitizedStudents);
+
+        return $sortedStudents;
     }
 
     public function sanitizeStudent($student, $imageManager = null)
@@ -121,5 +123,9 @@ class RosterRetrievalService implements RosterRetrievalContract
             'image_priority' => $student->image_priority,
             'recognized' => false,
         ];
+    }
+
+    private function sortStudents()
+    {
     }
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -24947,11 +24947,11 @@ var render = function() {
             on: { input: _vm.handleSelect }
           },
           [
-            _c("option", { attrs: { value: "1" } }, [_vm._v("First Name A-Z")]),
-            _vm._v(" "),
-            _c("option", { attrs: { value: "2", selected: "" } }, [
-              _vm._v("Last Name A-Z")
+            _c("option", { attrs: { value: "1", selected: "" } }, [
+              _vm._v("First Name A-Z")
             ]),
+            _vm._v(" "),
+            _c("option", { attrs: { value: "2" } }, [_vm._v("Last Name A-Z")]),
             _vm._v(" "),
             _c("option", { attrs: { value: "3" } }, [_vm._v("First Name Z-A")]),
             _vm._v(" "),

--- a/resources/src/js/components/roster_components/sortSelector.vue
+++ b/resources/src/js/components/roster_components/sortSelector.vue
@@ -2,8 +2,8 @@
     <div v-if="!this.flash">
         <label for="name-sorting"></label>
         <select name="name-sorting" id="name-sorting" @input="handleSelect">
-            <option value="1">First Name A-Z</option>
-            <option value="2" selected>Last Name A-Z</option>
+            <option value="1" selected>First Name A-Z</option>
+            <option value="2">Last Name A-Z</option>
             <option value="3">First Name Z-A</option>
             <option value="4">Last Name Z-A</option>
         </select>

--- a/tests/Services/RosterRetrievalServiceTest.php
+++ b/tests/Services/RosterRetrievalServiceTest.php
@@ -78,16 +78,6 @@ class RosterRetrievalServiceTest extends TestCase
 
         $cleanRoster = [
             [
-                'student_id' => 1,
-                'first_name' => 'Paul',
-                'last_name' => 'Blart',
-                'email' => 'cop@mall.com',
-                'images' => $images,
-                'image_priority' => 'likeness',
-                'recognized' => false,
-            ],
-
-            [
                 'student_id' => 3,
                 'first_name' => 'Big',
                 'last_name' => 'Jim',
@@ -102,6 +92,16 @@ class RosterRetrievalServiceTest extends TestCase
                 'first_name' => 'Frank',
                 'last_name' => 'Tank',
                 'email' => 'mountainman@parks.gov',
+                'images' => $images,
+                'image_priority' => 'likeness',
+                'recognized' => false,
+            ],
+
+            [
+                'student_id' => 1,
+                'first_name' => 'Paul',
+                'last_name' => 'Blart',
+                'email' => 'cop@mall.com',
                 'images' => $images,
                 'image_priority' => 'likeness',
                 'recognized' => false,


### PR DESCRIPTION
# Description
Changes the way default sorting occurs in order for the default roster to be first name a - z

(note: this was a backend change even though we marked it as a front end change. The front end sorting needs to be refactored since it is not clear whatsoever)
  
# Testing
Clear your backend cache (`php artisan cache:clear`) and front end cache and ensure that the default ordering is first name a-z as all ensuring that all tests still work
