### PR TITLE
NAM-tan-07-26-18 -- Added edit bubbles in gallery view and created theme styling

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -678,7 +678,7 @@ textarea[type="text"]:focus {
 }
 
 .theme-Dark .btn {
-  background-color: #4277ac;
+  background-color: #426c96;
   color: #dadada;
   border: 2px solid transparent;
 }
@@ -1114,12 +1114,35 @@ textarea[type="text"]:focus {
   padding: 5px !important;
 }
 
-.editButton {
+.panel__edit-button {
   position: absolute;
-  bottom: 22%;
-  right: 3%;
-  padding: 3%;
-  color: gray;
+  bottom: 25%;
+  right: 15%;
+  border-radius: 100%;
+  padding: 5%;
+  font-size: 150%;
+  -webkit-box-shadow: 1px 2px 2px 1px rgba(0, 0, 0, 0.07);
+  box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.07);
+}
+
+.theme-main .panel__edit-button {
+  background-color: #4F9DA3;
+  color: #ffffff;
+}
+
+.theme-bluesTheme .panel__edit-button {
+  background-color: #fff;
+  color: #2e88c5;
+}
+
+.theme-OnceAMatadorAlwaysAMatador .panel__edit-button {
+  background-color: #fff;
+  color: #808080;
+}
+
+.theme-Dark .panel__edit-button {
+  background-color: #426c96;
+  color: #dfe5ec;
 }
 
 .makeWhite {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21810,9 +21810,9 @@ var render = function() {
     "div",
     { staticClass: "col-xs-6 col-md-4 col-lg-3" },
     [
-      _c("div", { staticClass: "editButton" }, [
+      _c("div", [
         _c("i", {
-          staticClass: "fa fa-edit fa-2x",
+          staticClass: "fas fa-pencil-alt panel__edit-button",
           on: { click: _vm.checkPermission }
         })
       ]),

--- a/resources/src/js/components/roster_components/galleryCard.vue
+++ b/resources/src/js/components/roster_components/galleryCard.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="col-xs-6 col-md-4 col-lg-3">
-        <div class="editButton">
-            <i class="fa fa-edit fa-2x" @click="checkPermission"></i>
+        <div>
+            <i class="fas fa-pencil-alt panel__edit-button" @click="checkPermission"></i>
         </div>
         <router-link :to="'/profile/'+this.$route.params.id+'/'+email_uri">
         <div class="panel">

--- a/resources/src/sass/_helpers.scss
+++ b/resources/src/sass/_helpers.scss
@@ -120,12 +120,19 @@
 	padding: 5px !important;
 }
 
-.editButton {
-  position: absolute;
-  bottom: 22%;
-  right: 3%;
-  padding: 3%;
-  color: gray;
+.panel__edit-button {
+	position: absolute;
+    bottom: 25%;
+    right: 15%;
+    border-radius: 100%;
+    padding: 5%;
+    font-size: 150%;
+    -webkit-box-shadow: 1px 2px 2px 1px rgba(0, 0, 0, 0.07);
+	box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.07);
+	@include themify($themes) {
+		background-color: themed("galleryBtnBg");
+		color: themed("galleryBtnText");
+	}
 }
 
 .makeWhite {

--- a/resources/src/sass/_themes.scss
+++ b/resources/src/sass/_themes.scss
@@ -9,7 +9,7 @@ $themes: (
     mainFontSize: 1.1rem,
     mainFontFamily: sans-serif,
   ),
-  main: ( /*aka navy theme - Needs to be renamed*/
+  main: ( /*aka NAVY theme - Needs to be renamed*/
     navigationBars: #0F1821,
     accentColor: #4F9DA3,
     backgroundColor: #E5E5E5,
@@ -20,6 +20,9 @@ $themes: (
     
     buttonColor: #4F9DA3,
     buttonText: #fff,
+    /*Gallery - Styles gallery edit button colors*/
+    galleryBtnBg:#4F9DA3,
+    galleryBtnText: #ffffff,
     
     panelColor: #F4F4F4,
     toolBanner: rgba(255,255,255,0.5),
@@ -40,6 +43,9 @@ $themes: (
     buttonColor: #4CA1DB,
     buttonText: #fff,
 
+    galleryBtnBg:#fff,
+    galleryBtnText: #2e88c5,
+
     panelColor: white,
     toolBanner: rgba(255,255,255,0.5),
 
@@ -47,7 +53,7 @@ $themes: (
     mainFontFamily: sans-serif,
   ),
 
-  Cloudy: (
+  Cloudy: ( /*No longer being updated. Needs to be removed*/
     navigationBars: #747474,
     backgroundColor: #D8D8D8,
     textColor: #464646,
@@ -71,6 +77,9 @@ $themes: (
     hoverColor: rgb(221, 221, 221),
     focusColor: #92A1CD,
 
+    galleryBtnBg:#fff,
+    galleryBtnText: #808080,
+
     buttonColor: #E74A37,
     buttonText: #fff,
 
@@ -90,8 +99,11 @@ $themes: (
     hoverColor: #272727,
     focusColor: rgb(66, 119, 172),
 
-    buttonColor: rgb(66, 119, 172),
+    buttonColor: #426c96,
     buttonText: #dadada,
+
+    galleryBtnBg:#426c96,
+    galleryBtnText: #dfe5ec,
 
     panelColor: #303030,
     toolBanner: rgba(255,255,255,.05),


### PR DESCRIPTION
# Description
- Added edit bubbles in gallery cards
- Added theme colors for text and background for said edit bubbles
- Changed edit icon to pencil
  
# Testing
Test gallery view with all themes, play with mobile viewports and responsive settings to see that bubbles stay in correct position