### PR TITLE
NAM-tan-08-03-18 -- Refactored font family everywhere, added kerning

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -662,7 +662,7 @@ textarea[type="text"]:focus {
 }
 
 .tab__link--kerning {
-  letter-spacing: .13rem;
+  letter-spacing: .1rem;
 }
 
 .theme-login .tab__link--active {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -30,7 +30,6 @@ Compiles to 2.4rem*/
   color: white;
   text-decoration: none;
   font-size: 2.5vh;
-  font-family: sans-serif;
   margin: 0;
   text-decoration: none;
   text-align: center;
@@ -107,39 +106,37 @@ Compiles to 2.4rem*/
   padding-top: 2.4rem;
 }
 
+html * {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
 .theme-login html * {
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #FFFFFF;
 }
 
 .theme-main html * {
   font-size: 1.1rem;
-  font-family: helvetica;
   color: #E5E5E5;
 }
 
 .theme-bluesTheme html * {
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #d9e7ee;
 }
 
 .theme-Cloudy html * {
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #D8D8D8;
 }
 
 .theme-OnceAMatadorAlwaysAMatador html * {
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #FFFFFF;
 }
 
 .theme-Dark html * {
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #272727;
 }
 
@@ -1178,42 +1175,36 @@ textarea[type="text"]:focus {
 .theme-login .nav-bars {
   background-color: #D00D2D;
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #FFFFFF;
 }
 
 .theme-main .nav-bars {
   background-color: #0F1821;
   font-size: 1.1rem;
-  font-family: helvetica;
   color: #E5E5E5;
 }
 
 .theme-bluesTheme .nav-bars {
   background-color: #0D3753;
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #d9e7ee;
 }
 
 .theme-Cloudy .nav-bars {
   background-color: #747474;
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #D8D8D8;
 }
 
 .theme-OnceAMatadorAlwaysAMatador .nav-bars {
   background-color: #D22030;
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #FFFFFF;
 }
 
 .theme-Dark .nav-bars {
   background-color: #1D1D1D;
   font-size: 1.1rem;
-  font-family: sans-serif;
   color: #272727;
 }
 
@@ -1256,20 +1247,17 @@ textarea[type="text"]:focus {
 
 @media only screen and (min-width: 368px) {
   .student_list_name_mobile {
-    font-family: Arial, Helvetica, sans-serif;
     font-size: 1.3rem;
   }
 }
 
 @media only screen and (min-width: 600px) {
   .student_list_name {
-    font-family: Arial, Helvetica, sans-serif;
     font-size: 2rem;
   }
 }
 
 .cardText {
-  font-family: Arial, Helvetica, sans-serif;
   font-size: 4vh;
 }
 
@@ -1500,7 +1488,6 @@ textarea[type="text"]:focus {
   display: inline-block;
   padding: 6px 20px;
   margin: 0 3%;
-  font-family: "museo-sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 15px;
   font-weight: 500;
   line-height: 1.8;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -661,6 +661,10 @@ textarea[type="text"]:focus {
   border-bottom: none;
 }
 
+.tab__link--kerning {
+  letter-spacing: .13rem;
+}
+
 .theme-login .tab__link--active {
   display: block;
   padding: 5px 20px;
@@ -1237,6 +1241,8 @@ textarea[type="text"]:focus {
   color: white;
   width: 100%;
   border: 2px solid transparent;
+  font-weight: bold;
+  letter-spacing: .1rem;
 }
 
 @media only screen and (max-width: 367px) {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -891,6 +891,7 @@ textarea[type="text"]:focus {
   left: 50px;
   font-size: 1.5rem;
   color: white;
+  letter-spacing: .1rem;
 }
 
 .theme-login .csun_logo {

--- a/public/css/metaphor.css
+++ b/public/css/metaphor.css
@@ -226,10 +226,18 @@ th {
  */
 /* FONT PATH
  * -------------------------- */
-@font-face {
+/* @font-face {
   font-family: 'FontAwesome';
   src: url("../fonts/fontawesome-webfont.eot?v=4.7.0");
   src: url("../fonts/fontawesome-webfont.eot?#iefix&v=4.7.0") format("embedded-opentype"), url("../fonts/fontawesome-webfont.woff2?v=4.7.0") format("woff2"), url("../fonts/fontawesome-webfont.woff?v=4.7.0") format("woff"), url("../fonts/fontawesome-webfont.ttf?v=4.7.0") format("truetype"), url("../fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular") format("svg");
+  font-weight: normal;
+  font-style: normal;
+} */
+
+@font-face {
+  font-family: 'FontAwesome';
+  src: url('../fonts/fontawesome-webfont.eot?v=4.4.0');
+  src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.4.0') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff2?v=4.4.0') format('woff2'), url('../fonts/fontawesome-webfont.woff?v=4.4.0') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.4.0') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.4.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -241,6 +249,7 @@ th {
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
 /* makes the font 33% larger relative to the icon container */

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -20056,7 +20056,7 @@ var render = function() {
                     _vm._s(course.subject) +
                     " " +
                     _vm._s(course.catalog_number) +
-                    ": (" +
+                    " (" +
                     _vm._s(course.class_number) +
                     ")\n            "
                 )

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -18819,7 +18819,7 @@ var render = function() {
                     )
                   ]),
                   _vm._v(
-                    ": (" +
+                    " (" +
                       _vm._s(_vm.course.class_number) +
                       ")\n                    "
                   )
@@ -23906,7 +23906,7 @@ var render = function() {
   return _c("div", [
     _c("div", [
       _vm.showAbout
-        ? _c("ul", { staticClass: "tabs cf type--center" }, [
+        ? _c("ul", { staticClass: "tabs cf type--center tab__link--kerning" }, [
             _c("li", { staticClass: "tab__list" }, [
               _c(
                 "a",
@@ -23929,7 +23929,7 @@ var render = function() {
         : _vm._e(),
       _vm._v(" "),
       _vm.showAbout === false
-        ? _c("ul", { staticClass: "tabs cf type--center" }, [
+        ? _c("ul", { staticClass: "tabs cf type--center tab__link--kerning" }, [
             _c("li", { staticClass: "tab__list" }, [
               _c(
                 "a",
@@ -24180,8 +24180,8 @@ var render = function() {
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
   return _c("div", [
-    _c("div", { staticClass: "type--center tab__link" }, [
-      _vm._v("\n        Set Theme\n    ")
+    _c("div", { staticClass: "type--center tab__link tab__link--kerning" }, [
+      _vm._v("\n        Select Theme\n    ")
     ]),
     _vm._v(" "),
     _c("div", { staticClass: "panel" }, [

--- a/resources/src/js/components/about_components/aboutBanner.vue
+++ b/resources/src/js/components/about_components/aboutBanner.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
             <div>
-                <ul v-if="showAbout" class="tabs cf type--center">
+                <ul v-if="showAbout" class="tabs cf type--center tab__link--kerning">
                     <li class="tab__list">
                         <a class="tab__link--active" @click="selectAbout">About</a>
                     </li>
@@ -9,7 +9,7 @@
                         <a class="tab__link" @click="selectVersion">Version History</a>
                     </li>
                 </ul>
-                <ul v-if="showAbout === false" class="tabs cf type--center">
+                <ul v-if="showAbout === false" class="tabs cf type--center tab__link--kerning">
                     <li class="tab__list">
                         <a class="tab__link" @click="selectAbout">About</a>
                     </li>

--- a/resources/src/js/components/course_components/courseListItem.vue
+++ b/resources/src/js/components/course_components/courseListItem.vue
@@ -8,7 +8,7 @@
                 <div class="row">
                     <div class="col-xs-12 col-sm-6">
                         <div>
-                            <b>{{course.subject}} {{course.catalog_number}}</b>: ({{course.class_number}})
+                            <b>{{course.subject}} {{course.catalog_number}}</b> ({{course.class_number}})
                         </div>
                         <div>
                             {{course.enrollment_count}} Students

--- a/resources/src/js/components/fixed_components/themeSetting.vue
+++ b/resources/src/js/components/fixed_components/themeSetting.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
-    <div class="type--center tab__link">
-        Set Theme
+    <div class="type--center tab__link tab__link--kerning">
+        Select Theme
     </div>
 <div class="panel">
     <div class="colorThemes">

--- a/resources/src/js/components/roster_components/courseBanner.vue
+++ b/resources/src/js/components/roster_components/courseBanner.vue
@@ -3,7 +3,7 @@
         <li v-for="course in this.courses" :id="course.id" :key="course.title" :course="course" class="tab__list" @click="storeCourse(course.id)">
             <router-link :class="activeTab(course.id)" :to="'/class/'+course.id">
                 <div class="text_bold">
-                    {{course.subject}} {{course.catalog_number}}: ({{course.class_number}})
+                    {{course.subject}} {{course.catalog_number}} ({{course.class_number}})
                 </div>
             </router-link>
         </li>

--- a/resources/src/sass/_helpers.scss
+++ b/resources/src/sass/_helpers.scss
@@ -58,6 +58,8 @@
 	color: white;
 	width: 100%;
 	border: 2px solid transparent;
+    font-weight: bold;
+    letter-spacing: .1rem;
 }
 
 @media only screen and (max-width: 367px) {

--- a/resources/src/sass/_helpers.scss
+++ b/resources/src/sass/_helpers.scss
@@ -20,7 +20,6 @@
 	@include themify($themes) {
 		background-color: themed("navigationBars");
 		font-size: themed("mainFontSize");
-		font-family: themed("mainFontFamily");
 		color: themed("backgroundColor");
 	}
 }
@@ -69,20 +68,17 @@
 
 @media only screen and (min-width: 368px) {
 	.student_list_name_mobile {
-		font-family: Arial, Helvetica, sans-serif;
 		font-size: 1.3rem;
 	}
 }
 
 @media only screen and (min-width: 600px) {
 	.student_list_name {
-		font-family: Arial, Helvetica, sans-serif;
 		font-size: 2rem;
 	}
 }
 
 .cardText {
-	font-family: Arial, Helvetica, sans-serif;
 	font-size: 4vh;
 }
 
@@ -263,7 +259,6 @@
 	display: inline-block;
 	padding: 6px 20px;
 	margin: 0 3%;
-	font-family: "museo-sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 15px;
 	font-weight: 500;
 	line-height: 1.8;

--- a/resources/src/sass/_layout.scss
+++ b/resources/src/sass/_layout.scss
@@ -309,6 +309,7 @@ input, select, textarea{
 	left: 50px;
 	font-size: 1.5rem;
 	color: white;
+	letter-spacing: .1rem;
 }
 
 .csun_logo {

--- a/resources/src/sass/_layout.scss
+++ b/resources/src/sass/_layout.scss
@@ -7,9 +7,9 @@ body {
 }
 
 html * {
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	@include themify($themes) {
 		font-size: themed("mainFontSize");
-		font-family: themed("mainFontFamily");
 		color: themed("backgroundColor");
 	}
 }

--- a/resources/src/sass/_layout.scss
+++ b/resources/src/sass/_layout.scss
@@ -179,6 +179,10 @@ textarea[type="text"]:focus {
 	}
 }
 
+.tab__link--kerning {
+	letter-spacing: .13rem;
+}
+
 .tab__link--active {
 	@include themify($themes) {
 		display: block;

--- a/resources/src/sass/_layout.scss
+++ b/resources/src/sass/_layout.scss
@@ -180,7 +180,7 @@ textarea[type="text"]:focus {
 }
 
 .tab__link--kerning {
-	letter-spacing: .13rem;
+	letter-spacing: .1rem;
 }
 
 .tab__link--active {

--- a/resources/src/sass/_menu.scss
+++ b/resources/src/sass/_menu.scss
@@ -28,7 +28,6 @@
     color: white;
     text-decoration: none;
     font-size: 2.5vh;
-    font-family: sans-serif;
     margin: 0;
     text-decoration: none;
     text-align: center;

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -1,7 +1,7 @@
 /* Base */
 
 body, body *:not(html):not(style):not(br):not(tr):not(code) {
-    font-family: Avenir, Helvetica, sans-serif;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
# Description
- Found that font-family was inconsistent throughout NOMI, so changed everything to a Helvetica font stack
- Deleted superfluous font-family properties
- Removed colon on class list names since parenthesis already create visual separation
- Made font weight of themes to be bold to increase legibility for Matador theme against red
- Added font kerning (letter spacing) to tabs in Settings page, on semester in header, and on theme names
  
# Testing
- Please review application and verify that fonts look more consistent
- Make sure to look if font-type changing has misaligned anything in app
- Verify that kerning is not overdone
