### PR TITLE
NAM-352: UI: Add autocomplete="off" tag in notes on profile, wrap field in <form> element

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -23188,6 +23188,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
@@ -23260,24 +23261,26 @@ var render = function() {
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
   return _c("div", [
-    _c("textarea", {
-      staticClass: "notes_text",
-      attrs: { maxlength: "600", type: "text", id: "ex0", name: "ex0" },
-      domProps: { value: this.student.notes },
-      on: {
-        input: _vm.updateNotes,
-        keyup: function($event) {
-          if (
-            !("button" in $event) &&
-            _vm._k($event.keyCode, "enter", 13, $event.key)
-          ) {
-            return null
-          }
-          _vm.updateNotes($event)
-        },
-        click: _vm.scrollToNotes
-      }
-    }),
+    _c("form", { attrs: { autocomplete: "off" } }, [
+      _c("textarea", {
+        staticClass: "notes_text",
+        attrs: { maxlength: "600", type: "text", id: "ex0", name: "ex0" },
+        domProps: { value: this.student.notes },
+        on: {
+          input: _vm.updateNotes,
+          keyup: function($event) {
+            if (
+              !("button" in $event) &&
+              _vm._k($event.keyCode, "enter", 13, $event.key)
+            ) {
+              return null
+            }
+            _vm.updateNotes($event)
+          },
+          click: _vm.scrollToNotes
+        }
+      })
+    ]),
     _vm._v(" "),
     _c("div", { staticClass: "row" }, [
       _c("div", { staticClass: "col-xs-2" }, [

--- a/resources/src/js/components/profile_components/profileNotes.vue
+++ b/resources/src/js/components/profile_components/profileNotes.vue
@@ -1,7 +1,8 @@
 <template>
 	<div>
-		<textarea class="notes_text" maxlength="600" type="text" id="ex0" name="ex0" :value="this.student.notes" @input="updateNotes"
-		 @keyup.enter="updateNotes" @click="scrollToNotes"></textarea>
+		<form autocomplete="off">
+			<textarea class="notes_text" maxlength="600" type="text" id="ex0" name="ex0" :value="this.student.notes" @input="updateNotes" @keyup.enter="updateNotes" @click="scrollToNotes"></textarea>
+		</form>
 		<div class="row">
 			<div class="col-xs-2">
 				<span id="charCount" class="notes__status">{{characterCount}}/600</span>


### PR DESCRIPTION
# Description
Add autocomplete="off" tag in notes on profile, wrap field in <form> element
  
# Testing
Can't test it, but observe wrapped profile notes textarea with a form tag with an autocomplete ='off'

# Installation
none
