### PR TITLE
NAM-371 -- ENG and UI: Remove "Notes go here" text on back end and turn into placeholder

### DIFF
--- a/app/Services/StudentProfileService.php
+++ b/app/Services/StudentProfileService.php
@@ -60,7 +60,7 @@ class StudentProfileService implements StudentProfileContract
             'email' => $email,
             'student_id' => $profile['individuals_id'],
             'members_id' => $profile['individuals_id'],
-            'notes' => $note == null ? 'Notes go here.' : Crypt::decrypt($note->notepad),
+            'notes' => $note == null ? '' : Crypt::decrypt($note->notepad),
             'image_priority' => $imagePriority,
             'studentAudio' => $studentAudio,
         ];

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -23419,7 +23419,13 @@ var render = function() {
     _c("form", { attrs: { autocomplete: "off" } }, [
       _c("textarea", {
         staticClass: "notes_text",
-        attrs: { maxlength: "600", type: "text", id: "ex0", name: "ex0" },
+        attrs: {
+          placeholder: "Write about " + this.student.firstName + ".",
+          maxlength: "600",
+          type: "text",
+          id: "ex0",
+          name: "ex0"
+        },
         domProps: { value: this.student.notes },
         on: {
           input: _vm.updateNotes,

--- a/resources/src/js/components/profile_components/profileNotes.vue
+++ b/resources/src/js/components/profile_components/profileNotes.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<form autocomplete="off">
-			<textarea class="notes_text" maxlength="600" type="text" id="ex0" name="ex0" :value="this.student.notes" @input="updateNotes" @keyup.enter="updateNotes" @click="scrollToNotes"></textarea>
+			<textarea :placeholder="'Write about ' + this.student.firstName + '.'" class="notes_text" maxlength="600" type="text" id="ex0" name="ex0" :value="this.student.notes" @input="updateNotes" @keyup.enter="updateNotes" @click="scrollToNotes"></textarea>
 		</form>
 		<div class="row">
 			<div class="col-xs-2">


### PR DESCRIPTION
# Description
Remove "Notes go here" text on back end and turn into placeholder
_Commit that was mysteriously not added:_ Delete "Notes go here" from student profile php file and add placeholder to student notes component with the student's name.
  
# Testing
Sign in as Steve, go to Joseph's profile and observe the notes section. 

# Installation
none
