### PR TITLE
NAM-369 -- UI: Make student bio in profile only visible when student has filled in information

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1638,7 +1638,7 @@ textarea {
 }
 
 .profile_notes_padding {
-  padding-top: 2rem;
+  padding-top: 1rem;
 }
 
 .modal_btn {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -23247,6 +23247,8 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
 
 
 
@@ -23544,15 +23546,18 @@ var render = function() {
               ]),
               _vm._v(" "),
               _c("div", [
-                _c("strong", [
-                  _vm._v("About " + _vm._s(this.student.firstName) + ":")
-                ]),
-                _vm._v(" "),
-                this.student.bio == null
+                this.student.bio != null
                   ? _c("span", { staticClass: "text_italic display_inline" }, [
-                      _vm._v(" Pending biography from student.")
+                      _c("strong", [
+                        _vm._v("About " + _vm._s(this.student.firstName) + ":")
+                      ]),
+                      _vm._v(
+                        "\n                        " +
+                          _vm._s(this.student.bio) +
+                          "\n                    "
+                      )
                     ])
-                  : _c("span", [_vm._v(" " + _vm._s(this.student.bio))])
+                  : _c("span")
               ]),
               _vm._v(" "),
               _c("profile-notes", {

--- a/resources/src/js/components/profile_components/profileInfo.vue
+++ b/resources/src/js/components/profile_components/profileInfo.vue
@@ -8,9 +8,11 @@
                         {{this.student.emailURI}}@my.csun.edu
                     </div>
                     <div>
-                        <strong>About {{this.student.firstName}}:</strong>
-                        <span v-if="this.student.bio == null" class="text_italic display_inline"> Pending biography from student.</span>
-                        <span v-else> {{this.student.bio}}</span>
+                        <span v-if="this.student.bio != null" class="text_italic display_inline">
+                            <strong>About {{this.student.firstName}}:</strong>
+                            {{this.student.bio}}
+                        </span>
+                        <span v-else></span>
                     </div>
                     <profile-notes class="profile_notes_padding" :student="student" @unsavedChanges="sendUnsavedChanges" @committedChanges="sendChanges"></profile-notes>
                 </div>

--- a/resources/src/sass/_helpers.scss
+++ b/resources/src/sass/_helpers.scss
@@ -269,7 +269,7 @@
 }
 
 .profile_notes_padding {
-	padding-top: 2rem;
+	padding-top: 1rem;
 }
 
 .modal_btn {


### PR DESCRIPTION
# Description
Make student bio in profile only visible when student has filled in information.
  
# Testing
Sign as Steve and choose a student profile. Then observe that they no longer have a bio, since none of the students have written any. 

# Installation
none
