### PR TITLE
NAM-408 -- BUG: Shuffle button overlaps navigation bar in mobile view

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1508,7 +1508,7 @@ textarea {
   position: fixed;
   z-index: 1;
   right: 20px;
-  bottom: 9%;
+  bottom: 80px;
   padding: 12px;
   border-radius: 50%;
   -webkit-box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);

--- a/public/css/metaphor.css
+++ b/public/css/metaphor.css
@@ -226,18 +226,10 @@ th {
  */
 /* FONT PATH
  * -------------------------- */
-/* @font-face {
+@font-face {
   font-family: 'FontAwesome';
   src: url("../fonts/fontawesome-webfont.eot?v=4.7.0");
   src: url("../fonts/fontawesome-webfont.eot?#iefix&v=4.7.0") format("embedded-opentype"), url("../fonts/fontawesome-webfont.woff2?v=4.7.0") format("woff2"), url("../fonts/fontawesome-webfont.woff?v=4.7.0") format("woff"), url("../fonts/fontawesome-webfont.ttf?v=4.7.0") format("truetype"), url("../fonts/fontawesome-webfont.svg?v=4.7.0#fontawesomeregular") format("svg");
-  font-weight: normal;
-  font-style: normal;
-} */
-
-@font-face {
-  font-family: 'FontAwesome';
-  src: url('../fonts/fontawesome-webfont.eot?v=4.4.0');
-  src: url('../fonts/fontawesome-webfont.eot?#iefix&v=4.4.0') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff2?v=4.4.0') format('woff2'), url('../fonts/fontawesome-webfont.woff?v=4.4.0') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.4.0') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.4.0#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -249,7 +241,6 @@ th {
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
 }
 
 /* makes the font 33% larger relative to the icon container */

--- a/resources/src/sass/_helpers.scss
+++ b/resources/src/sass/_helpers.scss
@@ -233,7 +233,7 @@
 	position: fixed;
 	z-index: 1;
 	right: 20px;
-	bottom: 9%;
+	bottom: 80px;
 	padding: 12px;
 	border-radius: 50%;
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);

--- a/resources/views/spa.blade.php
+++ b/resources/views/spa.blade.php
@@ -4,6 +4,6 @@
     <permission-modal></permission-modal>
     <router-view></router-view>
     <side-menu></side-menu>
-    <div id="menu-bar-padding" style="height:60px"></div>
+    <div id="menu-bar-padding" style="height:80px"></div>
     <menu-bar></menu-bar>
 @stop


### PR DESCRIPTION
# Description
Set the shuffle button position to be a fixed property so it stays constant on all viewports.
  
# Testing
1. Ensure the shuffle button is at the proper position at all viewports.
