### PR TITLE
NAM-402 -- ENG: Login page sets /login in URL after failed login. Upon refresh, this breaks the app.

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 /** Routes associated with login. */
 Route::get('/', 'LoginController@index')->name('login');
+Route::get('/login', 'LoginController@index')->name('login');
 Route::post('/login', 'LoginController@validateUser')->name('post.login');
 
 /** Route for home page. Takes us to the SPA. */
@@ -26,8 +27,7 @@ Route::get('/logout', function () {
     return redirect('/');
 });
 
-/** Login API Routes */
-Route::get('/login', 'LoginController@validateUser')->middleware('auth');
+
 
 /** Web Service API Routes. */
 Route::get('/courses/{term}', 'WebResourceController@courses')->middleware('auth');

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,9 @@ Route::get('/logout', function () {
     return redirect('/');
 });
 
+/** Login API Routes */
+Route::get('/login', 'LoginController@validateUser')->middleware('auth');
+
 /** Web Service API Routes. */
 Route::get('/courses/{term}', 'WebResourceController@courses')->middleware('auth');
 Route::get('/roster/{term}/{course}', 'WebResourceController@roster')->middleware('auth');


### PR DESCRIPTION
# Description
There should be a GET route for /login which should render the same thing as /
  
# Testing
Login incorrectly.
Once it says that login failed, refresh the page. 
Nothing should break. 

# Installation
nope
