### PR TITLE
HOTFIX-9-26-2018-fixTermSelectorClipping

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -598,12 +598,12 @@ textarea[type="text"]:focus {
 }
 
 .fullscreen-width {
-  width: 100vw;
+  width: 100%;
   position: relative;
   left: 50%;
   right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
+  margin-left: -50%;
+  margin-right: -50%;
 }
 
 .mb-0 {
@@ -1112,6 +1112,12 @@ textarea[type="text"]:focus {
 
 .theme-Dark .course__descriptor {
   color: #bababa !important;
+}
+
+.course__banner {
+  position: relative;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .theme-login .course__banner {
@@ -2126,12 +2132,12 @@ textarea[type="text"]:focus {
 }
 
 .fullscreen-width {
-  width: 100vw;
+  width: 100%;
   position: relative;
   left: 50%;
   right: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
+  margin-left: -50%;
+  margin-right: -50%;
 }
 
 /*  Fixed Safari font-awesome issue

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19076,7 +19076,7 @@ var render = function() {
   return _c("div", [
     this.shouldLoadClasses
       ? _c("div", { staticClass: "type--center" }, [
-          _c("div", { staticClass: "row course__banner fullscreen-width" }, [
+          _c("div", { staticClass: "row course__banner" }, [
             _vm._m(0),
             _vm._v(" "),
             _c("div", { staticClass: "col-xs-4 type--right" }, [
@@ -19135,7 +19135,7 @@ var render = function() {
       : _c(
           "div",
           [
-            _c("div", { staticClass: "row course__banner fullscreen-width" }, [
+            _c("div", { staticClass: "row course__banner" }, [
               _vm._m(1),
               _vm._v(" "),
               _c("div", { staticClass: "col-xs-4 type--right" }, [

--- a/resources/src/js/components/course_components/coursesContainer.vue
+++ b/resources/src/js/components/course_components/coursesContainer.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div v-if="this.shouldLoadClasses" class="type--center">
-            <div class="row course__banner fullscreen-width">
+            <div class="row course__banner">
                 <div class="col-xs-12 type--center">
                     <h1 class="course__descriptor">Selected Term</h1>
                 </div>
@@ -19,7 +19,7 @@
             <i class="fa fa-spinner fa-spin fa-3x icon__theme"></i>
         </div>
         <div v-else>
-            <div class="row course__banner fullscreen-width">
+            <div class="row course__banner">
                 <div class="col-xs-12 type--center">
                     <h1 class="course__descriptor">Selected Term</h1>
                 </div>

--- a/resources/src/sass/_helpers.scss
+++ b/resources/src/sass/_helpers.scss
@@ -112,12 +112,12 @@ textarea[type="text"]:focus{
 }
 
 .fullscreen-width {
-	width: 100vw;
+	width: 100%;
 	position: relative;
 	left: 50%; 
 	right: 50%;
-	margin-left: -50vw;
-	margin-right: -50vw;
+	margin-left: -50%;
+	margin-right: -50%;
 }
 
 .mb-0 {

--- a/resources/src/sass/modules/_courses.scss
+++ b/resources/src/sass/modules/_courses.scss
@@ -33,6 +33,10 @@
 	}
 
 	&__banner {
+		position: relative;
+		width: 100%;
+		margin: 0 auto;
+
 		@include themify($themes) {
 			background-color: themed("toolBanner");
 			color: themed("textColor");

--- a/resources/src/sass/modules/_student-page.scss
+++ b/resources/src/sass/modules/_student-page.scss
@@ -332,10 +332,10 @@
 }
 
 .fullscreen-width {
-	width: 100vw;
+	width: 100%;
 	position: relative;
 	left: 50%;
 	right: 50%;
-	margin-left: -50vw;
-	margin-right: -50vw;
+	margin-left: -50%;
+	margin-right: -50%;
 }


### PR DESCRIPTION
# Description
Fixed an issue where the application would clip on the x-axis (horizontal) due to the selector containers in courses and student being out of bounds.
  
# Testing
1. Visit the courses and students page and ensure there is no longer a scroll bar on the bottom of the browser in different screen resolutions.
