### PR TITLE
NAM-313 -- UI: Actually fix profile bug and remove workaround

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -22653,41 +22653,27 @@ var render = function() {
             1
           ),
           _vm._v(" "),
-          _c(
-            "div",
-            { staticClass: "col-xs-9 col-md-10" },
-            [
+          _c("div", { staticClass: "col-xs-9 col-md-10" }, [
+            _c("span", [
               _c(
-                "router-link",
+                "div",
                 {
-                  attrs: {
-                    to:
-                      "/profile/" + this.$route.params.id + "/" + _vm.email_uri
-                  }
+                  staticClass:
+                    "student_list_first_name student_list_first_name_mobile"
                 },
-                [
-                  _c(
-                    "div",
-                    {
-                      staticClass:
-                        "student_list_first_name student_list_first_name_mobile"
-                    },
-                    [_vm._v(_vm._s(this.student.first_name))]
-                  ),
-                  _vm._v(" "),
-                  _c(
-                    "div",
-                    {
-                      staticClass:
-                        "student_list_last_name student_list_last_name_mobile"
-                    },
-                    [_vm._v(_vm._s(this.student.last_name))]
-                  )
-                ]
+                [_vm._v(_vm._s(this.student.first_name))]
+              ),
+              _vm._v(" "),
+              _c(
+                "div",
+                {
+                  staticClass:
+                    "student_list_last_name student_list_last_name_mobile"
+                },
+                [_vm._v(_vm._s(this.student.last_name))]
               )
-            ],
-            1
-          )
+            ])
+          ])
         ])
       ])
     ]
@@ -23945,7 +23931,8 @@ var render = function() {
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
   return _c("div", [
-    this.studentProfile.images == null
+    this.studentProfile.images == null ||
+    this.$route.params.emailURI != this.studentProfile.emailURI
       ? _c("div", { staticClass: "type--center" }, [
           _c("br"),
           _vm._v(" "),
@@ -26126,11 +26113,6 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 //
 //
 //
-//
-//
-//
-//
-//
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
@@ -26138,10 +26120,8 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
     methods: {
         goBack: function goBack() {
-            if (document.getElementById('charCount')) {
-                this.$store.dispatch('clearStudent');
-                this.$router.push({ name: 'class', params: { id: this.currentCourse } });
-            } else this.$router.go(-1);
+            this.$store.dispatch('clearStudent');
+            this.$router.replace({ name: 'class', params: { id: this.currentCourse } });
         }
     },
 
@@ -26158,20 +26138,11 @@ var render = function() {
   var _c = _vm._self._c || _h
   return !_vm.hideBack
     ? _c("div", [
-        !_vm.disableBack
-          ? _c("div", [
-              _c("i", {
-                staticClass: "fa fa-angle-left fa-3x back-button",
-                attrs: { title: "Go Back" },
-                on: { click: _vm.goBack }
-              })
-            ])
-          : _c("div", [
-              _c("i", {
-                staticClass:
-                  "fa fa-angle-left fa-3x back-button back-button--disabled"
-              })
-            ])
+        _c("i", {
+          staticClass: "fa fa-angle-left fa-3x back-button",
+          attrs: { title: "Go Back" },
+          on: { click: _vm.goBack }
+        })
       ])
     : _vm._e()
 }

--- a/resources/src/js/components/fixed_components/backButton.vue
+++ b/resources/src/js/components/fixed_components/backButton.vue
@@ -1,11 +1,6 @@
 <template>
     <div v-if="!hideBack">
-        <div v-if="!disableBack">
-            <i class="fa fa-angle-left fa-3x back-button" title="Go Back" @click="goBack"></i>
-        </div>
-        <div v-else>
-            <i class="fa fa-angle-left fa-3x back-button back-button--disabled"></i>
-        </div>
+        <i class="fa fa-angle-left fa-3x back-button" title="Go Back" @click="goBack"></i>
     </div>
 </template>
 
@@ -16,12 +11,8 @@
 
         methods: {
             goBack: function () {
-                if(document.getElementById('charCount')){
-                    this.$store.dispatch('clearStudent');
-                    this.$router.push({name: 'class', params: {id: this.currentCourse}});
-                }
-                else
-                    this.$router.go(-1);
+                this.$store.dispatch('clearStudent');
+                this.$router.replace({name: 'class', params: {id: this.currentCourse}});
             }
         },
 

--- a/resources/src/js/components/roster_components/studentListItem.vue
+++ b/resources/src/js/components/roster_components/studentListItem.vue
@@ -6,10 +6,10 @@
                 <profile-picture class="pull-left" :name="display_name" :image="image" :type="'roster'"></profile-picture>
             </div>
             <div class="col-xs-9 col-md-10">
-                <router-link :to="'/profile/'+this.$route.params.id+'/'+email_uri">
+                <span>
                     <div class="student_list_first_name student_list_first_name_mobile">{{this.student.first_name}}</div>
                     <div class="student_list_last_name student_list_last_name_mobile">{{this.student.last_name}}</div>
-                </router-link>
+                </span>
             </div>
         </div>
         </div>

--- a/resources/src/js/views/profile.vue
+++ b/resources/src/js/views/profile.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div v-if="this.studentProfile.images == null" class="type--center">
+        <div v-if="(this.studentProfile.images == null) || (this.$route.params.emailURI != this.studentProfile.emailURI)" class="type--center">
             <br>
             <br>
             <i class="fa fa-spinner fa-spin fa-3x icon__theme"></i>


### PR DESCRIPTION
# Description
Added feature to allow the user to back out of a student profile route. Fixed bug from swapping in between profiles.
  
# Testing
1. Visit the student page; click on any student and back out to ensure no weird bug happens.
2. Randomly click on students while clicking the back button during load; lastly visit a profile and ensure it routes to the correct profile.
3. Ensure when clicking a student profile while backing out of loading, make sure that when switching between course and student page the student button will redirect to the student page and not the previous student profile.  
