### PR TITLE
docker-compose.yml removal of broken composer container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,4 @@ services:
       - '8080:80'
     volumes:
       - .:/var/www/
-  composer:
-    image: composer:latest
-    command: install
-    volumes:
-      - .:/app/
+  


### PR DESCRIPTION
# Description
Removes broken composer container in the docker-compose.yml file. Manual composer install will have to be done for new Nomi members or anyone who freshly clones the repo. 
# Testing
N/A

# Installation
N/A
