### PR TITLE
NAM-483 -- UI: Set favicon to NOMI icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ yarn-error.log
 .php_cs.cache
 *.DS_STORE
 public/images/*/
-public/images/apple-touch-icon.png


### PR DESCRIPTION
# Description
updated gitignore to no longer ignore default favicon
  
# Testing
Make sure gitignore is updated and that public/images/apple-touch-icon.png is the correct image
