### PR TITLE
HOTFIX-1-11-2019--fix-find-current-term

### DIFF
--- a/app/ModelRepositories/TermModelRepository.php
+++ b/app/ModelRepositories/TermModelRepository.php
@@ -12,13 +12,17 @@ class TermModelRepository implements TermModelRepositoryInterface
 {
     public function find($today): array
     {
-        $currentTerm = Term::currentTerm($today)
-        ->first();
+        $terms = Term::nowAndNextTerm(1)->get();
+        $currentTerm = $terms->first();
+        $nextTerm = $terms->last();
 
-        while ($currentTerm == null) {
-            $today = Carbon::parse($today)->addWeeks(1)->toDateTimeString();
-            $currentTerm = Term::currentTerm($today)
-          ->first();
+        $today = Carbon::today();
+        $nextStart = Carbon::parse($nextTerm->begin_date);
+        $diff = $today->diffInDays($nextStart);
+
+        // is next term 3 weeks away
+        if ($diff >= 0 && $diff <= 21) {
+            return $nextTerm->toArray();
         }
 
         return $currentTerm->toArray();

--- a/app/Models/Term.php
+++ b/app/Models/Term.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 
 class Term extends Model
@@ -16,5 +17,11 @@ class Term extends Model
     {
         return $query->where('begin_date', '<=', $today)
         ->where('end_date', '>=', $today);
+    }
+
+    public function scopeNowAndNextTerm($query, $take = 2)
+    {
+        return $query->where('end_date', '>', Carbon::now())
+              ->orderBy('end_date')->take($take + 1);
     }
 }


### PR DESCRIPTION
# Description
Grab current term, correctly, this time
  
# Testing
make sure nomi isn't broken
comment out the .env value CURRENT_TERM
term should now be today

# Installation
no