### PR TITLE
NAM-524 -- ENG: Remove getMedia() from WebResourceRetrieverService.

### DIFF
--- a/app/Contracts/WebResourceRetrieverContract.php
+++ b/app/Contracts/WebResourceRetrieverContract.php
@@ -10,8 +10,6 @@ interface WebResourceRetrieverContract
 
     public function getRoster($term, $course);
 
-    public function getMedia($email);
-
     public function getStudent($email);
 
     public function gatherImageCorrectly($student);

--- a/app/Http/Controllers/WebResourceController.php
+++ b/app/Http/Controllers/WebResourceController.php
@@ -44,16 +44,6 @@ class WebResourceController extends Controller
     }
 
     /**
-     * @param mixed $email
-     *
-     * @return mixed
-     */
-    public function media($email)
-    {
-        return $this->webResourceUtility->getMedia($email);
-    }
-
-    /**
      * @param $email
      *
      * @return mixed

--- a/app/Services/WebResourceRetrieverService.php
+++ b/app/Services/WebResourceRetrieverService.php
@@ -39,8 +39,8 @@ class WebResourceRetrieverService implements WebResourceRetrieverContract
         }
 
         //ensure array is sorted by class_number
-        usort($data, function($item,$item2) {
-            return strcmp($item->class_number, $item2->class_number);
+        \usort($data, function ($item, $item2) {
+            return \strcmp($item->class_number, $item2->class_number);
         });
 
         return $data;
@@ -75,25 +75,6 @@ class WebResourceRetrieverService implements WebResourceRetrieverContract
                 echo Psr7\str($e->getResponse());
             }
         }
-    }
-
-    /**
-     * Retrieves media from META+LAB Media web service.
-     *
-     * @param mixed $email
-     *
-     * @return string
-     */
-    public function getMedia($email)
-    {
-        $client = new Client();
-
-        //hacky fix to remove @csun.edu
-        return $client->get(
-            'http://api.sandbox.csun.edu/metalab/test/media/1.1/' . $emailUri . '/photo'
-            . \explode('@', \str_replace('nr_', '', $email))[0],
-            ['verify' => false]
-        )->getBody()->getContents();
     }
 
     public function getStudent($email)

--- a/tests/Controllers/WebResourceControllerTest.php
+++ b/tests/Controllers/WebResourceControllerTest.php
@@ -54,20 +54,6 @@ class WebResourceControllerTest extends TestCase
     /**
      * @test
      */
-    public function getMedia_calls_roster_in_retriever()
-    {
-        $controller = new WebResourceController($this->retriever);
-
-        $this->retriever
-            ->shouldReceive('getMedia')
-            ->once();
-
-        $controller->media('thisisanemail');
-    }
-
-    /**
-     * @test
-     */
     public function getStudent_makes_call_in_retriever()
     {
         $controller = new WebResourceController($this->retriever);

--- a/tests/Services/StudentProfileServiceTest.php
+++ b/tests/Services/StudentProfileServiceTest.php
@@ -65,11 +65,6 @@ class StudentProfileServiceTest extends TestCase
                 'status' => '200',
         ]));
 
-        $this->webResourceRetriever
-            ->shouldReceive('getMedia')
-            ->withArgs([$email])
-            ->andReturn(\json_encode(['media' => [0 => ['audio' => 'haha']]]));
-
         $this->imageCRUD
             ->shouldReceive('getPriority')
             ->withArgs([['student']])


### PR DESCRIPTION
# Description
removes unused getMedia() method
  
# Testing
1. Ensure getMedia was removed from codebase
2. Ensure application is still functioning correctly
