### PR TITLE
NAM-544 -- UI: Back-button in Feedback page does not redirect immediately

### DIFF
--- a/resources/views/vendor/support/forms/feedback.blade.php
+++ b/resources/views/vendor/support/forms/feedback.blade.php
@@ -114,7 +114,7 @@
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <script>
       function backtoNOMI(){
-        window.location.href = '/home';
+        window.history.back();
       }
     </script>
 


### PR DESCRIPTION
# Description
Not sure exactly what this task entailed but I believe forcing the browser history going back one page is better than redirecting to the home route.
  
# Testing
1. Visit the feedback page.
2. Click the back button and ensure it redirects "immediately".
