### PR TITLE
NAM-548 -- FE: Hitting checkmark without croppa process being started

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -40496,7 +40496,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
             var _this2 = this;
 
             if (!this.myCroppa.hasImage()) {
-                alert('no image');
+                this.$parent.$emit('close');
             } else {
                 var url = this.myCroppa.generateDataUrl('jpg', .8);
                 var emuri = this.student.email_uri;

--- a/resources/src/js/components/profile_components/croppaProfile.vue
+++ b/resources/src/js/components/profile_components/croppaProfile.vue
@@ -72,7 +72,7 @@
             },
             confirmImage: function () {
                 if (!this.myCroppa.hasImage()) {
-                    alert('no image');
+                    this.$parent.$emit('close');
                 } else {
                     let url = this.myCroppa.generateDataUrl('jpg', .8);
                     let emuri = this.student.email_uri;
@@ -128,8 +128,6 @@
                 if(this.myCroppa.$refs.fileInput) {
                     this.fileInput = this.myCroppa.$refs.fileInput;
                     this.myCroppa.chooseFile();
-                    
-                   
                 } else {
                     this.myCroppa.$refs.fileInput = this.fileInput;
                     this.myCroppa.chooseFile();


### PR DESCRIPTION
# Description
Removed the alert for no image when a user hits the confirm button without uploading.
  
# Testing
1. Visit gallery or student profile and open the upload modal.
2. Click the confirm button and ensure it just closes the modal instead of giving you an alert message for no image.