### PR TITLE
NAM-549 -- FE: Profile Carousel is not swipeable, and can only be navigated by the dots at the bottom

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -905,6 +905,7 @@ textarea[type="text"]:focus {
 
 .panel__edit-button-sim {
   position: absolute;
+  pointer-events: none;
   top: 0;
   height: 70%;
   width: 100%;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -926,6 +926,7 @@ textarea[type="text"]:focus {
 
 .panel__edit-button--profile {
   position: absolute;
+  pointer-events: auto;
   bottom: 0;
   right: 0;
   margin: 2.5%;

--- a/resources/src/sass/_helpers.scss
+++ b/resources/src/sass/_helpers.scss
@@ -106,6 +106,7 @@ textarea[type="text"]:focus{
 
 	&-sim {
 		position: absolute;
+		pointer-events: none;
 		top: 0;
 		height: 70%;
 		width: 100%;

--- a/resources/src/sass/_helpers.scss
+++ b/resources/src/sass/_helpers.scss
@@ -127,6 +127,7 @@ textarea[type="text"]:focus{
 
 	&--profile{
 		position: absolute;
+		pointer-events: auto;
 		bottom: 0;
 		right: 0;
 		margin: 2.5%;


### PR DESCRIPTION
# Description
Removed pointer events on panel simulation for edit button.

# Testing
1. Visit any student profile.
2. Make sure you can swipe through student and faculty uploaded.
