### PR TITLE
NAM-551 -- FE: Fix term selection logic

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -29797,6 +29797,7 @@ module.exports = Component.exports
   semester: null,
   termYear: null,
   term: null,
+  initialTerm: [],
   selectedTerm: 'current',
   loadingClasses: true,
   currentCourse: null,
@@ -34813,6 +34814,9 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
       if (this.term != null) {
         var termCode = this.term;
         switch (termCode.charAt(3)) {
+          case '1':
+            this.displayedTerm = 'Winter';
+            break;
           case '3':
             this.displayedTerm = 'Spring';
             break;
@@ -34824,6 +34828,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
             break;
           case '9':
             this.displayedTerm = 'Winter';
+            break;
         }
         if (termCode.charAt(0) == '2') {
           this.displayedTerm += ' ' + termCode.charAt(0) + '0' + termCode.substring(1, 3);
@@ -35738,6 +35743,9 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
       if (this.term != null) {
         var termCode = this.term;
         switch (termCode.charAt(3)) {
+          case '1':
+            this.displayedTerm = 'Winter';
+            break;
           case '3':
             this.displayedTerm = 'Spring';
             break;
@@ -35749,6 +35757,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
             break;
           case '9':
             this.displayedTerm = 'Winter';
+            break;
         }
         if (termCode.charAt(0) == '2') {
           this.displayedTerm += ' ' + termCode.charAt(0) + '0' + termCode.substring(1, 3);
@@ -36239,27 +36248,32 @@ var displayCurrentTerm = {
         };
     },
 
+
     computed: _extends({}, Object(__WEBPACK_IMPORTED_MODULE_0_vuex__["c" /* mapGetters */])(['term']), {
         displayCurrentTerm: function displayCurrentTerm() {
             if (this.term != null) {
                 var termCode = this.term;
                 switch (termCode.charAt(3)) {
+                    case '1':
+                        this.displayedTerm = 'Winter' + ' ';
+                        break;
                     case '3':
-                        this.displayedTerm = 'Spring';
+                        this.displaye1dTerm = 'Spring' + ' ';
                         break;
                     case '5':
-                        this.displayedTerm = 'Summer';
+                        this.displayedTerm = 'Summer' + ' ';
                         break;
                     case '7':
-                        this.displayedTerm = 'Fall';
+                        this.displayedTerm = 'Fall' + ' ';
                         break;
                     case '9':
-                        this.displayedTerm = 'Winter';
+                        this.displayedTerm = 'Winter' + ' ';
+                        break;
                 }
                 if (termCode.charAt(0) == '2') {
-                    this.displayedTerm += ' ' + termCode.charAt(0) + '0' + termCode.substring(1, 3);
+                    this.displayedTerm += termCode.charAt(0) + '0' + termCode.substring(1, 3);
                 } else {
-                    this.displayedTerm += ' ' + termCode.charAt(0) + '9' + termCode.substring(1, 3);
+                    this.displayedTerm += termCode.charAt(0) + '9' + termCode.substring(1, 3);
                 }
                 return this.displayedTerm;
             }
@@ -36291,7 +36305,7 @@ var render = function() {
                     { staticClass: "panel__header course__header--empty mb-0" },
                     [
                       _vm._v(
-                        "\n                    You did not teach any classes for " +
+                        "\n                    You did not teach any classes for " +
                           _vm._s(_vm.displayedTerm) +
                           ".\n                "
                       )
@@ -36335,7 +36349,7 @@ var render = function() {
                       },
                       [
                         _vm._v(
-                          "\n                You are not teaching any classes for " +
+                          "\n                You are not teaching any classes for " +
                             _vm._s(_vm.displayedTerm) +
                             ".\n            "
                         )
@@ -36380,7 +36394,7 @@ var render = function() {
                         },
                         [
                           _vm._v(
-                            "\n                You are not scheduled to teach any classes for " +
+                            "\n                You are not scheduled to teach any classes for " +
                               _vm._s(_vm.displayedTerm) +
                               ".\n            "
                           )
@@ -44686,22 +44700,18 @@ function t(t,n,r){return void 0===(t=(n.split?n.split("."):n).reduce(function(t,
     state.loadingClasses = true;
     state.termYear = state.term.slice(0, 3);
     state.semester = state.term.slice(3);
-    if (state.selectedTerm == 'current') {
-      state.semester -= 2;
-      if (state.semester < 3) {
-        state.semester = 9;
-        state.termYear -= 1;
-      }
-    } else if (state.selectedTerm == 'next') {
-      state.semester -= 4;
-      if (state.semester == 1) {
-        state.semester = 9;
-        state.termYear -= 1;
-      } else if (state.semester == -1) {
-        state.semester = 7;
-        state.termYear -= 1;
-      }
+
+    if (state.semester === 1) {
+      state.semester = 9;
+      state.termYear -= 1;
     }
+
+    state.semester -= 2;
+
+    if (state.selectedTerm === 'next') {
+      state.semester -= 2;
+    }
+
     state.term = '' + state.termYear + state.semester;
     state.termYear = '' + state.termYear;
     state.termYear = state.termYear.slice(0, 1) + 0 + state.termYear.slice(1);
@@ -44718,22 +44728,18 @@ function t(t,n,r){return void 0===(t=(n.split?n.split("."):n).reduce(function(t,
     state.loadingClasses = true;
     state.termYear = parseInt(state.term.slice(0, 3));
     state.semester = parseInt(state.term.slice(3));
-    if (state.selectedTerm == 'current') {
-      state.semester += 2;
-      if (state.semester > 9) {
-        state.semester = 3;
-        state.termYear += 1;
-      }
-    } else if (state.selectedTerm == 'previous') {
-      state.semester += 4;
-      if (state.semester == 11) {
-        state.semester = 3;
-        state.termYear += 1;
-      } else if (state.semester == 13) {
-        state.semester = 5;
-        state.termYear += 1;
-      }
+
+    if (state.semester === 9) {
+      state.semester = 1;
+      state.termYear += 1;
     }
+
+    state.semester += 2;
+
+    if (state.selectedTerm === 'previous') {
+      state.semester += 2;
+    }
+
     state.term = '' + state.termYear + state.semester;
     state.termYear = '' + state.termYear;
     state.termYear = state.termYear.slice(0, 1) + 0 + state.termYear.slice(1);

--- a/resources/src/js/components/course_components/coursesContainer.vue
+++ b/resources/src/js/components/course_components/coursesContainer.vue
@@ -81,6 +81,9 @@ import courseList from './courseList';
           if (this.term != null) {
             const termCode = this.term;
             switch (termCode.charAt(3)) {
+              case '1':
+                this.displayedTerm = 'Winter';
+                break;
               case '3':
                 this.displayedTerm = 'Spring';
                 break;
@@ -92,6 +95,7 @@ import courseList from './courseList';
                 break;
               case '9':
                 this.displayedTerm = 'Winter';
+                break;
             }
             if (termCode.charAt(0) == '2') {
               this.displayedTerm

--- a/resources/src/js/components/course_components/emptyCourseItem.vue
+++ b/resources/src/js/components/course_components/emptyCourseItem.vue
@@ -3,7 +3,7 @@
     <div v-if="selectedTerm == 'previous'">
         <div class="panel col-lg-12 col-md-12 col-xs-12 type--center">
                 <h5  class="panel__header course__header--empty mb-0">
-                    You did not teach any classes for {{displayedTerm}}.
+                    You did not teach any classes for&nbsp;{{displayedTerm}}.
                 </h5>
         <div class="panel__content course__content--empty">
             <div class="row">If you notice any errors in your class schedule, please <a :href="this.url + '/support'">let us know</a>.</div>
@@ -15,7 +15,7 @@
     <div v-else-if="selectedTerm == 'current'">
         <div class="panel col-lg-12 col-md-12 col-xs-12 type--center">
             <h5 class="panel__header course__header--empty mb-0">
-                You are not teaching any classes for {{displayedTerm}}.
+                You are not teaching any classes for&nbsp;{{displayedTerm}}.
             </h5>
         <div class="panel__content course__content--empty">
             <div class="row">If you notice any errors in your class schedule, please <a :href="this.url + '/support'">let us know</a>.</div>
@@ -27,7 +27,7 @@
     <div v-else-if="selectedTerm == 'next'">
         <div class="panel col-lg-12 col-md-12 col-xs-12 type--center">
             <h5 class="panel__header course__header--empty mb-0">
-                You are not scheduled to teach any classes for {{displayedTerm}}.
+                You are not scheduled to teach any classes for&nbsp;{{displayedTerm}}.
             </h5>
         <div class="panel__content course__content--empty">
             <div class="row">If you notice any errors in your class schedule, please 
@@ -57,6 +57,6 @@ export default {
 
     created() {
         this.url = document.querySelector('meta[name=app-url]').content;
-    },
+    }
 };
 </script>

--- a/resources/src/js/components/fixed_components/navBar.vue
+++ b/resources/src/js/components/fixed_components/navBar.vue
@@ -33,6 +33,9 @@ export default {
       if (this.term != null) {
         const termCode = this.term;
         switch (termCode.charAt(3)) {
+          case '1':
+            this.displayedTerm = 'Winter';
+            break;
           case '3':
             this.displayedTerm = 'Spring';
             break;
@@ -44,6 +47,7 @@ export default {
             break;
           case '9':
             this.displayedTerm = 'Winter';
+            break;
         }
         if (termCode.charAt(0) == '2') {
           this.displayedTerm

--- a/resources/src/js/mixins/displayCurrentTerm.js
+++ b/resources/src/js/mixins/displayCurrentTerm.js
@@ -2,44 +2,42 @@ import { mapGetters } from 'vuex';
 export const displayCurrentTerm = {
     data() {
         return {
-              displayedTerm: '',
+            displayedTerm: '',
         }
-      },
-      computed: {
-        ...mapGetters([
-          'term'
-        ]),
-        displayCurrentTerm() {
-            if (this.term != null) {
-            const termCode = this.term;
-            switch (termCode.charAt(3)) {
-                case '3':
-                this.displayedTerm = 'Spring';
-                break;
-                case '5':
-                this.displayedTerm = 'Summer';
-                break;
-                case '7':
-                this.displayedTerm = 'Fall';
-                break;
-                case '9':
-                this.displayedTerm = 'Winter';
-            }
-            if (termCode.charAt(0) == '2') {
-                this.displayedTerm
-                            += ` ${
-                            termCode.charAt(0)
-                            }0${
-                            termCode.substring(1, 3)}`;
-            } else {
-                this.displayedTerm
-                            += ` ${
-                            termCode.charAt(0)
-                            }9${
-                            termCode.substring(1, 3)}`;
-            }
-            return this.displayedTerm;
-            }
-        },
-    }
+    },
+
+    computed: {
+    ...mapGetters([
+        'term'
+    ]),
+
+    displayCurrentTerm() {
+        if (this.term != null) {
+        const termCode = this.term;
+        switch (termCode.charAt(3)) {
+            case '1':
+            this.displayedTerm = 'Winter' + ' ';
+            break;
+            case '3':
+            this.displaye1dTerm = 'Spring' + ' ';
+            break;
+            case '5':
+            this.displayedTerm = 'Summer' + ' ';
+            break;
+            case '7':
+            this.displayedTerm = 'Fall' + ' ';
+            break;
+            case '9':
+            this.displayedTerm = 'Winter' + ' ';
+            break;
+        }
+        if (termCode.charAt(0) == '2') {
+            this.displayedTerm += `${termCode.charAt(0)}0${termCode.substring(1, 3)}`;
+        } else {
+            this.displayedTerm += `${termCode.charAt(0)}9${termCode.substring(1, 3)}`;
+        }
+        return this.displayedTerm;
+        }
+    },
+}
 }

--- a/resources/src/js/store/modules/base/mutations.js
+++ b/resources/src/js/store/modules/base/mutations.js
@@ -240,22 +240,18 @@ export default {
     state.loadingClasses = true;
     state.termYear = state.term.slice(0, 3);
     state.semester = state.term.slice(3);
-    if (state.selectedTerm == 'current') {
-      state.semester -= 2;
-      if (state.semester < 3) {
-        state.semester = 9;
-        state.termYear -= 1;
-      }
-    } else if (state.selectedTerm == 'next') {
-      state.semester -= 4;
-      if (state.semester == 1) {
-        state.semester = 9;
-        state.termYear -= 1;
-      } else if (state.semester == -1) {
-        state.semester = 7;
-        state.termYear -= 1;
-      }
+
+    if (state.semester === 1) {
+      state.semester = 9;
+      state.termYear -= 1;
     }
+
+    state.semester -= 2;
+
+    if (state.selectedTerm === 'next') {
+      state.semester -= 2;
+    }
+
     state.term = `${state.termYear}${state.semester}`;
     state.termYear = `${state.termYear}`;
     state.termYear = state.termYear.slice(0, 1) + 0 + state.termYear.slice(1);
@@ -274,22 +270,18 @@ export default {
     state.loadingClasses = true;
     state.termYear = parseInt(state.term.slice(0, 3));
     state.semester = parseInt(state.term.slice(3));
-    if (state.selectedTerm == 'current') {
-      state.semester += 2;
-      if (state.semester > 9) {
-        state.semester = 3;
-        state.termYear += 1;
-      }
-    } else if (state.selectedTerm == 'previous') {
-      state.semester += 4;
-      if (state.semester == 11) {
-        state.semester = 3;
-        state.termYear += 1;
-      } else if (state.semester == 13) {
-        state.semester = 5;
-        state.termYear += 1;
-      }
+
+    if (state.semester === 9) {
+      state.semester = 1;
+      state.termYear += 1;
     }
+
+    state.semester += 2;
+
+    if (state.selectedTerm === 'previous') {
+      state.semester += 2;
+    }
+
     state.term = `${state.termYear}${state.semester}`;
     state.termYear = `${state.termYear}`;
     state.termYear = state.termYear.slice(0, 1) + 0 + state.termYear.slice(1);

--- a/resources/src/js/store/modules/base/state.js
+++ b/resources/src/js/store/modules/base/state.js
@@ -26,6 +26,7 @@ export default {
   semester: null,
   termYear: null,
   term: null,
+  initialTerm: [],
   selectedTerm: 'current',
   loadingClasses: true,
   currentCourse: null,


### PR DESCRIPTION
# Description
Currently when visiting Steve's profile, when you select previous term it should be Winter 2019 not Winter 2018. We should fix the underlying logic issue with term selection.
  
# Testing
1. Visit steve's profile and go to courses page.
2. Ensure previous is Winter 2019; current is Spring 2019; and next is Summer 2019 **ALL THE TIME**.
3. Try to abuse the interactions by refreshing, spam clicking, change between different terms in different orders, etc.